### PR TITLE
Make the qrSize configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ import (
 var (
 	defaultPort = "8080"
 	defaultSize = 256
+	minQrSize   = 128
+	maxQrSize   = 2048
 )
 
 func fetchImageFromURL(url string) (image.Image, error) {
@@ -62,10 +64,22 @@ func (s *server) makeGenerateQRCodeHandler() http.HandlerFunc {
 			text = textParam
 		}
 
-		qrSizeParam := r.URL.Query().Get("size")
-		size, err := strconv.Atoi(qrSizeParam)
+		if r.URL.Query().Has("size") {
+			qrSizeParam := r.URL.Query().Get("size")
+			size, err := strconv.Atoi(qrSizeParam)
 
-		if err == nil {
+			if err != nil {
+				http.Error(w, "Invalid QR size, it should be between 128 to 2048", http.StatusBadRequest)
+				slog.Error("Invalid QR size, it should be between 128 to 2048", err)
+				return
+			}
+
+			if size < minQrSize || size > maxQrSize {
+				http.Error(w, "Invalid QR size, it should be between 128 to 2048", http.StatusBadRequest)
+				slog.Error("Invalid QR size, it should be between 128 to 2048")
+				return
+			}
+
 			qrSize = size
 		}
 

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func (s *server) makeGenerateQRCodeHandler() http.HandlerFunc {
 
 			if err != nil {
 				http.Error(w, "Invalid QR size, it should be between 128 to 2048", http.StatusBadRequest)
-				slog.Error("Invalid QR size, it should be between 128 to 2048", err)
+				slog.Error("Invalid QR size, it should be between 128 to 2048", "error", err)
 				return
 			}
 

--- a/main.go
+++ b/main.go
@@ -18,6 +18,11 @@ import (
 	"github.com/skip2/go-qrcode"
 )
 
+var (
+	defaultPort = "8080"
+	defaultSize = 256
+)
+
 func fetchImageFromURL(url string) (image.Image, error) {
 	// The default HTTP client does not have any timeout so it can hang forever.
 	// It is therefore recommended to create a new client with a timeout.
@@ -51,7 +56,7 @@ func (s *server) makeGenerateQRCodeHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		text := s.text
 		logoPath := s.logoPath
-		qrSize := 256
+		qrSize := defaultSize
 
 		if textParam := r.URL.Query().Get("text"); textParam != "" {
 			text = textParam
@@ -118,7 +123,7 @@ func main() {
 		logoPath: os.Getenv("LOGO_PATH"),
 	}
 	if srv.port == "" {
-		srv.port = "8080"
+		srv.port = defaultPort
 	}
 	err := run(srv) // Use a special function to run the server so it is easier to test
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestQrSize(t *testing.T) {
+	s := &server{
+		port: "8080",
+		text: "sample",
+	}
+
+	handler := s.makeGenerateQRCodeHandler()
+
+	tests := []struct {
+		TestName           string
+		QrSize             string
+		ExpectedStatusCode int
+	}{
+		{
+			TestName:           "Should return 400, for non integer qr size",
+			QrSize:             "abc",
+			ExpectedStatusCode: 400,
+		},
+		{
+			TestName:           "Should return 400, for qr size less than 128",
+			QrSize:             "100",
+			ExpectedStatusCode: 400,
+		},
+		{
+			TestName:           "Should return 400, for qr size greater than 2048",
+			QrSize:             "3000",
+			ExpectedStatusCode: 400,
+		},
+		{
+			TestName:           "Should return 200, for valid qr size",
+			QrSize:             "300",
+			ExpectedStatusCode: 200,
+		},
+	}
+
+	for _, test := range tests {
+		url := "/?text=happy-coding&size=" + test.QrSize
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != test.ExpectedStatusCode {
+			t.Fatalf("Expected status code %d, got %d", test.ExpectedStatusCode, rec.Code)
+		}
+	}
+}


### PR DESCRIPTION
- Use `256` as the default `qrSize`
- Update default `qrSize` when the URL contains a valid size in the `size` query